### PR TITLE
Run text through the filter before displaying

### DIFF
--- a/src/Components/Comment.lua
+++ b/src/Components/Comment.lua
@@ -7,6 +7,7 @@ local Types = require(TeamComments.Types)
 local Styles = require(TeamComments.Styles)
 local Immutable = require(TeamComments.Lib.Immutable)
 local useTheme = require(TeamComments.Hooks.useTheme)
+local useTextFilter = require(TeamComments.Hooks.useTextFilter)
 local Avatar = require(script.Parent.Avatar)
 local MessageMeta = require(script.Parent.MessageMeta)
 local MessageActions = require(script.Parent.MessageActions)
@@ -26,11 +27,10 @@ local AVATAR_SIZE = 64
 local function Comment(props, hooks)
 	props = Immutable.join(defaultProps, props)
 
-	print(props)
-
 	assert(validateProps(props))
 
 	local theme = useTheme(hooks)
+	local text = useTextFilter(hooks, props.message.userId, props.message.text)
 
 	return Roact.createElement("Frame", {
 		LayoutOrder = props.LayoutOrder,
@@ -89,7 +89,7 @@ local function Comment(props, hooks)
 				"TextLabel",
 				Immutable.join(Styles.Text, {
 					LayoutOrder = 2,
-					Text = props.message.text,
+					Text = text,
 					TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText),
 				})
 			),

--- a/src/Hooks/useTextFilter.lua
+++ b/src/Hooks/useTextFilter.lua
@@ -1,0 +1,27 @@
+local Players = game:GetService("Players")
+local TextService = game:GetService("TextService")
+
+local Promise = require(script.Parent.Parent.Packages.Promise)
+
+local fetchFilteredText = Promise.promisify(function(userId, text)
+	local numericUserId = tonumber(userId)
+	local result = TextService:FilterStringAsync(text, numericUserId)
+
+	if numericUserId == Players.LocalPlayer.UserId then
+		return result:GetNonChatStringForBroadcastAsync()
+	else
+		return result:GetChatForUserAsync(Players.LocalPlayer.UserId)
+	end
+end)
+
+local function useTextFilter(hooks, userId, text)
+	local filteredText, set = hooks.useState(text:gsub(".", "_"))
+
+	hooks.useEffect(function()
+		fetchFilteredText(userId, text):andThen(set)
+	end, { set })
+
+	return filteredText
+end
+
+return useTextFilter


### PR DESCRIPTION
Doesn't seem like this actually works. It's got everything it's supposed to, but I think Studio doesn't actually run the text filter at all. Users might just be able to swear to each other.

Closes #9 (if this can even work)